### PR TITLE
Use database storage for Active Storage in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,8 +29,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  # Store uploaded files in the database to avoid Heroku ephemeral filesystem loss.
+  config.active_storage.service = :database
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,9 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+database:
+  service: Database
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
- Switch production Active Storage service from :local to :database to avoid Heroku’s ephemeral filesystem wiping uploads.
- Add the database service definition in config/storage.yml.

Why
- Heroku wipes local disk on dyno restart; uploads were disappearing. Database-backed storage keeps blobs in Postgres, so uploads persist across restarts without extra infra.

Notes
- No Heroku env var changes required; uses existing Active Storage tables.
- Existing missing files won’t return; users may need to re-upload.
- DB size will grow with uploads; monitor Postgres usage.